### PR TITLE
Restore test refactor

### DIFF
--- a/faq-site/.vscode/settings.json
+++ b/faq-site/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+    "cSpell.words": [
+        "Apim",
+        "COVID",
+        "Kbid",
+        "Knowledgebase",
+        "debounced",
+        "dont",
+        "qnamaker",
+        "slugify",
+        "subcat",
+        "subcats",
+        "unmark"
+    ]
+}

--- a/faq-site/tools/deployToProd.js
+++ b/faq-site/tools/deployToProd.js
@@ -65,7 +65,7 @@ async function replaceKnowledgeBase(sourceClient, targetClient) {
     let sourceKnowledgeBase = await sourceClient.knowledgeBase.download();
     let testKbid = targetClient.knowledgeBase.kbId;
     //call replace 
-    let knowledgeBaseReplaceResonse = await targetClient.knowledgeBase.replace(0, { qnaList: sourceKnowledgeBase.qnaDocuments });
-    //return bool to indicate if relace was successful
-    return knowledgeBaseReplaceResonse.status === STATUS_SUCCESS;
+    let knowledgeBaseReplaceResponse = await targetClient.knowledgeBase.replace(0, { qnaList: sourceKnowledgeBase.qnaDocuments });
+    //return bool to indicate if replace was successful
+    return knowledgeBaseReplaceResponse.status === STATUS_SUCCESS;
 }

--- a/faq-site/tools/deployToProd.js
+++ b/faq-site/tools/deployToProd.js
@@ -7,8 +7,8 @@ module.exports = deployToProd();
 
 async function deployToProd() {
 
-    let sourceEnv = require('dotenv').config({ path: ".env.prod" })
-    let targetEnv = require('dotenv').config({ path: ".env.test" })
+    let sourceEnv = require('dotenv').config({ path: ".env.test" })
+    let targetEnv = require('dotenv').config({ path: ".env.prod" })
 
     if (sourceEnv.error) {
         console.error("Source Environment file not found: ", sourceEnv.error.path)

--- a/faq-site/tools/faqsByTopic.js
+++ b/faq-site/tools/faqsByTopic.js
@@ -44,7 +44,7 @@ async function buildFAQsByTopic() {
         let uniqueSubCats = getSubCategories(catFaqs, topics, cat)
 
 
-        // bin faqs into subcategtories
+        // bin faqs into subcategories
         let subCatCollection = uniqueSubCats.map(subCat => {
             let subCatFaqs = catFaqs.filter(faq => utilities.stringsAlphaEqual(faq.metadata.subcategory, subCat))
 

--- a/faq-site/tools/restoreTestKb.js
+++ b/faq-site/tools/restoreTestKb.js
@@ -103,7 +103,7 @@ async function getTestKb(clientFromTest){
     //passing the 'TEST' lookup  means that the kb returned will reflect what is currently in editor rather than what is published.
     let currentlyOnTestKB = await clientFromTest.knowledgeBase.download(undefined, clientFromTest.lookups.ENVIRONMENT.TEST);
 
-    let downLoadSuccessful = JSON.stringify(currentlyOnTestKB) !== '{}'
+    let downLoadSuccessful = !utilities.isEmptyObj(currentlyOnTestKB)
 
     let errorInfo = "";
     if (currentlyOnTestKB.hasOwnProperty("error")) {
@@ -171,7 +171,8 @@ async function pollForUpdateComplete(clientFromTest, opId){
 async function publishKb(clientFromTest){
     console.log("\n" + 'Publishing test knowledge base...')
     let publishResponse = await clientFromTest.knowledgeBase.publish(process.env.kbId)
-    let publishWasSuccessful = JSON.stringify(publishResponse) !== '{}' && !publishResponse.hasOwnProperty("error")
+    let publishWasSuccessful = !utilities.isEmptyObj(publishResponse) && !publishResponse.hasOwnProperty("error")
+
     if(publishWasSuccessful){
         console.log('Publish successful')
         return;

--- a/faq-site/tools/utilities.js
+++ b/faq-site/tools/utilities.js
@@ -89,6 +89,15 @@ function slugify(title) {
     return slug;
 }
 
+/**
+ * Test whether item is is empty object `{}`
+ * @param {object} obj 
+ * @description See also: https://stackoverflow.com/q/679915/1366033
+ */
+function isEmptyObj(obj) {
+    return JSON.stringify(obj) === JSON.stringify({});
+}
+
 function getCurrentTimestamp() {
     var time = new Date();
     var options = {

--- a/faq-site/tools/utilities.js
+++ b/faq-site/tools/utilities.js
@@ -7,6 +7,7 @@ module.exports = {
     flattenArrayToObject,
     readJsonc,
     slugify,
+    isEmptyObj,
     getCurrentTimestamp,
     deduplicate
 }

--- a/kb-node-client/ReadMe.md
+++ b/kb-node-client/ReadMe.md
@@ -13,7 +13,7 @@ npm install @ads-vdh/qnamaker-api --save
 
 ## Usage
 
-**Initialize the Client**:
+### Initialize the Client:
 
 ```js
 let qnaMakerApi = require("@ads-vdh/qnamaker-api");
@@ -25,23 +25,38 @@ let client = qnaMakerApi({
 });
 ```
 
-**Knowledge Base Methods**:
+### Knowledge Base Methods:
 
 ```js
-let knowledgeBases = await client.knowledgeBase.listAll();
 let knowledgeBase = await client.knowledgeBase.download(kbId);
 let kbDetails = await client.knowledgeBase.getDetails(kbId);
+let knowledgeBases = await client.knowledgeBase.listAll();
+
+
 
 await client.knowledgeBase.publish(kbId);
 await client.knowledgeBase.replace(kbId, qnaList);
-await client.knowledgeBase.replace(kbId, qnaUpdates);
 ```
 
-**Alterations Methods**:
+#### qnaUpdates parameter is a modified qna list:
+```js
+await client.knowledgeBase.update(kbId, qnaUpdates);
+```
+
+### Alterations Methods:
 
 ```js
 let alterations = await client.alterations.get();
 await client.alterations.replace(alterations);
+```
+
+### Operations Methods:
+
+```js
+await client.operations.getDetails(operationId);
+```
+```js
+await client.operations.pollForOperationComplete(operationId);
 ```
 
 ## Recommendations

--- a/kb-node-client/index.js
+++ b/kb-node-client/index.js
@@ -274,32 +274,44 @@ let QnAMakerAPI = function(config) {
 
             return operationDetails
 
-        }
-    }
+        },
+      /**
+       * Check kb operation once a second to see if operation state is updated to either a success of failure state
+       * @param {string} operationId operation ID
+       * @param {number} [secondsWaited] (optional) number of seconds waited already
+       * @description Returns details of kb operation https://docs.microsoft.com/en-us/rest/api/cognitiveservices/qnamaker/operations/getdetails
+       */
+        pollForOperationComplete: async function(operationId, secondsWaited) {
 
-    let marshaling = {
-        updateAndPublish: async function(kbId, body) {
+            let seconds = secondsWaited || 0
 
-            let updateResponse = await knowledgeBase.update(kbId, body)
-
-            //Get operation state for update
-            let updateJson = await updateResponse.json();
-            let opId = updateJson.operationId;
-
-            let updateOperationState = await pollForOperationComplete(opId);
-
-            let updateWasSuccessful = updateOperationState === OPERATION_STATE.SUCCEEDED;
-
-            // default response
-            let publishResponse = "";
-
-            if (updateWasSuccessful) {
-                publishResponse = await knowledgeBase.publish(kbId)
+            //success and failure are both completed states
+            let completeStates = [OPERATION_STATE.FAILED, OPERATION_STATE.SUCCEEDED]
+    
+            //get operation details
+            let detailsResponse = await operations.getDetails(operationId)
+            let operationDetailsRetrieved = JSON.stringify(detailsResponse) !== '{}' && !detailsResponse.hasOwnProperty("error")
+    
+            if(!operationDetailsRetrieved){
+                throw "Unable to get operation details";
+            }
+            //get operation state
+            let operationState = detailsResponse.operationState;
+    
+            //If operation is complete (failure or success), or if operation has timed out, return the current state
+            if (completeStates.includes(operationState) || seconds > NUMBER_SECONDS_FOR_TIMEOUT) {
+    
+                return operationState;
+    
+            } else {
+                //if operation is not complete, and it has not timed out, wait a second and then call this method again recursively 
+                await sleepForOneSecond() //TODO test this
+    
+                return await pollForOperationComplete(operationId, seconds + 1); //todo use incrementor
             }
 
-            return publishResponse;
-
         }
+
     }
 
     // compose client to return
@@ -307,7 +319,6 @@ let QnAMakerAPI = function(config) {
         knowledgeBase,
         alterations,
         operations,
-        marshaling,
         lookups: {
             METHOD,
             ENVIRONMENT,

--- a/kb-node-client/index.js
+++ b/kb-node-client/index.js
@@ -305,7 +305,7 @@ let QnAMakerAPI = function(config) {
     
             } else {
                 //if operation is not complete, and it has not timed out, wait a second and then call this method again recursively 
-                await sleepForOneSecond() //TODO test this
+                await sleepForOneSecond()
     
                 return await pollForOperationComplete(operationId, seconds + 1); //todo use incrementor
             }

--- a/kb-node-client/index.js
+++ b/kb-node-client/index.js
@@ -283,7 +283,7 @@ let QnAMakerAPI = function(config) {
                 //if operation is not complete, and it has not timed out, wait a second and then call this method again recursively 
                 await sleepForOneSecond()
     
-                return await pollForOperationComplete(operationId, ++seconds);
+                return await this.pollForOperationComplete(operationId, ++seconds);
             }
 
         }

--- a/kb-node-client/index.js
+++ b/kb-node-client/index.js
@@ -144,7 +144,7 @@ let QnAMakerAPI = function(config) {
          */
         download: async function(kbId, environment) {
             kbId = kbId || config.kbId
-            environment = environment || "prod"
+            environment = environment || ENVIRONMENT.PROD
 
             let url = `${config.endpoint}/qnamaker/${API_VERSION}/knowledgebases/${kbId}/${environment}/qna`
 


### PR DESCRIPTION
Main issue that this update solves is that the kb is not able to add and delete follow up prompts that point to the same question in the same update. Deleting and then Adding is the process we need to use to change existing follow up prompts. In order to make changes to existing follow up prompts, we have to identify when they are occurring, process the delete step in one update and then process the addition of the new version in a second update. 

This update also includes extra formatting and updates to the Kb api readme